### PR TITLE
Fixed and enabled: cancel upload

### DIFF
--- a/client/app/collections/upload_queue.coffee
+++ b/client/app/collections/upload_queue.coffee
@@ -179,6 +179,8 @@ module.exports = class UploadQueue
                     else if err.status is 400 and body.code is 'ESTORAGE'
                         model.markAsErrored body
 
+                    else if err.status is 0 and err.statusText is 'error'
+                        # abort by user, don't try again
 
                     # Retry if an unexpected error occurs
                     else

--- a/client/app/views/styles/_main.styl
+++ b/client/app/views/styles/_main.styl
@@ -736,8 +736,6 @@ tr.folder-row.uploading
         .operations
             display none
 
-    .cancel-upload-button
-        display none
 
 tr.folder-row.broken
     background-color #FEE


### PR DESCRIPTION
This requires more testing because there are so many cases that I might have missed some.

The issues were:
* on the server, the rollback function was called twice
* on the client, the abort was not handled in the error case so it triggers 3 more requests that didn't do anything until they timeout