### PR TITLE
Multiple selection improvements + fix behaviour for folder overwrite

### DIFF
--- a/client/app/locales/de.coffee
+++ b/client/app/locales/de.coffee
@@ -19,6 +19,8 @@ Mozilla Firefox unterstütz kein Hochladen von Ordner. Wenn Sie dieses
 Merkmal benötigen, es ist verfügbar in Chromium, Chrome und Safari Browsern.
 """
 
+    "modal error existing folder": "Le dossier \"%{name}\" existe déjà. Il n'est pas encore possible d'écraser un dossier."
+
     "root folder name"          : "root"
 
     "confirmation reload"      : "Eine Opration ist noch aktiv, sind Sie sicher die Seite zu aktualisieren bzw. neu zu laden?"
@@ -74,10 +76,10 @@ Merkmal benötigen, es ist verfügbar in Chromium, Chrome und Safari Browsern.
 
     "chrome error dragdrop title": "Dateien werden ignoriert"
     "chrome error dragdrop content": """
-        Druch einen Bug in Chrome, wird die folgende Datei: %{files} 
+        Druch einen Bug in Chrome, wird die folgende Datei: %{files}
         aufgrund eines Akzent im Namen ignoriert. Sie können diese mit
         der Schaltfläche oben rechts im Bild weiterhin hinzufügen. ||||
-        Druch einen Bug in Chrome, werden die folgenden Dateien: %{files} 
+        Druch einen Bug in Chrome, werden die folgenden Dateien: %{files}
         aufgrund eines Akzent in deren Namen ignoriert. Sie können diese mit
         der Schaltfläche oben rechts im Bild weiterhin hinzufügen.
     """

--- a/client/app/locales/en.coffee
+++ b/client/app/locales/en.coffee
@@ -19,6 +19,8 @@ Mozilla Firefox doesn't support folder uploading. If you need this
 feature, it's available in Chromium, Chrome and Safari browsers.
 """
 
+    "modal error existing folder": "Folder \"%{name}\" already exists. It is currently not possible to overwrite a folder."
+
     "root folder name"          : "root"
 
     "confirmation reload"      : "An operation is in progress, are you sure you want to reload the page?"
@@ -186,7 +188,7 @@ feature, it's available in Chromium, Chrome and Safari browsers.
     """
     "mail not sent"                   : "Mail not sent"
     "postfix error"                   : """ Mail not sent.
-                                            Can you check that all recipient adresses are correct 
+                                            Can you check that all recipient adresses are correct
                                             and that your Cozy is well configured to send messages ?
                                         """
     "yes forgot"                      : "Back"

--- a/client/app/locales/es.coffee
+++ b/client/app/locales/es.coffee
@@ -11,6 +11,7 @@ module.exports =
     "modal error file invalid":"""El archivo no parece válido"""
     "modal error firefox dragdrop folder":"""Mozilla Firefox no administra la carga de dossiers. Si usted necesita
 esta función, los navegadores Chromium, Chrome y Safari disponen de ella."""
+    "modal error existing folder": "Folder \"%{name}\" already exists. It is currently not possible to overwrite a folder."
     "root folder name":"""root"""
     "confirmation reload":"""Una operación se halla en curso. ¿Está usted seguro(a) que quiere recargar la página?"""
     "breadcrumbs search title":"""Buscar"""

--- a/client/app/locales/fr.coffee
+++ b/client/app/locales/fr.coffee
@@ -20,6 +20,7 @@ Mozilla Firefox ne gère pas le téléversement de dossiers. Si vous avez besoin
 de cette fonctionnalité, elle est disponible avec les navigateurs Chromium,
 Chrome et Safari.
 """
+    "modal error existing folder": "Le dossier \"%{name}\" existe déjà. Il n'est pas encore possible d'écraser un dossier."
 
     "root folder name"          : "racine"
 
@@ -184,7 +185,7 @@ Chrome et Safari.
         Les changements effectués sur les permissions ne seront pas sauvegardés. Êtes-vous sûr(e) ?
     """
     "mail not sent"                   : "Le mail n'a pas pu être envoyé"
-    "postfix error"                   : """ Le mail n'a pas pu être envoyé. 
+    "postfix error"                   : """ Le mail n'a pas pu être envoyé.
                                             Vérifiez que les adresses de tous les destinataires sont valides
                                             et que votre Cozy est bien configuré pour envoyer des messages.
                                             """

--- a/client/app/models/file.coffee
+++ b/client/app/models/file.coffee
@@ -5,7 +5,7 @@ client = require '../lib/client'
 Represent a file or folder document.
 
 
-# Local state and Shared state
+# Local state and Shared state.
 There is a concept of local state and shared state in the application, it is
 handled in this class.
 
@@ -17,6 +17,9 @@ The shared state is shared with other clients through websockets.
 Both are needed in order to support various features like conflict management,
 upload cancel, or broken file detection.
 
+# View state.
+The state "selected" is only relevant into the view, but it's handy to manage
+it in the model.
 ###
 module.exports = class File extends Backbone.Model
 
@@ -29,6 +32,9 @@ module.exports = class File extends Backbone.Model
 
     # Local state. Handled through `markAsErrored` method.
     error: null
+
+    # View state. Handled through *viewSelected
+    viewSelected: false
 
     # Valid values for `uploadStatus`.
     @VALID_STATUSES: [null, 'uploading', 'uploaded', 'errored', 'conflict']
@@ -114,6 +120,21 @@ module.exports = class File extends Backbone.Model
         Getter for the shared state.
     ###
     isServerUploading: -> return @get 'uploading'
+
+
+
+    ###
+        Manage view state.
+        The state "selected" is only relevant into the view, but it's handy
+        to manage it in the model.
+    ###
+    isViewSelected: -> return @viewSelected
+
+    toggleViewSelected: -> @setSelectedViewState not @viewSelected
+
+    setSelectedViewState: (viewSelected) ->
+        @viewSelected = viewSelected
+        @trigger 'toggle-select', viewSelected
 
 
     # Remove server's additional information

--- a/client/app/models/file.coffee
+++ b/client/app/models/file.coffee
@@ -130,11 +130,14 @@ module.exports = class File extends Backbone.Model
     ###
     isViewSelected: -> return @viewSelected
 
-    toggleViewSelected: -> @setSelectedViewState not @viewSelected
 
-    setSelectedViewState: (viewSelected) ->
+    toggleViewSelected: (isShiftPressed = false) ->
+        @setSelectedViewState not @isViewSelected(), isShiftPressed
+
+
+    setSelectedViewState: (viewSelected, isShiftPressed = false) ->
         @viewSelected = viewSelected
-        @trigger 'toggle-select', viewSelected
+        @trigger 'toggle-select', isShiftPressed
 
 
     # Remove server's additional information

--- a/client/app/models/file.coffee
+++ b/client/app/models/file.coffee
@@ -119,7 +119,7 @@ module.exports = class File extends Backbone.Model
     ###
         Getter for the shared state.
     ###
-    isServerUploading: -> return @get 'uploading'
+    isServerUploading: -> return @get('uploading') and not @inUploadCycle()
 
 
 

--- a/client/app/views/file_view.coffee
+++ b/client/app/views/file_view.coffee
@@ -390,14 +390,11 @@ module.exports = class FileView extends BaseView
 
     # Show loading spinner.
     showLoading: ->
-        @$('.icon-zone .fa').addClass 'hidden'
-        @$('.icon-zone .selector-wrapper').addClass 'hidden'
+        @$('.link-wrapper .fa').addClass 'hidden'
         @$('.spinholder').css 'display', 'inline-block'
 
 
     # Hide loading spinner.
     hideLoading: ->
-        @$('.icon-zone .fa').removeClass 'hidden'
-        @$('.icon-zone .selector-wrapper').removeClass 'hidden'
+        @$('.link-wrapper .fa').removeClass 'hidden'
         @$('.spinholder').hide()
-

--- a/client/app/views/file_view.coffee
+++ b/client/app/views/file_view.coffee
@@ -355,7 +355,8 @@ module.exports = class FileView extends BaseView
         # If none of the forbidden elements has been clicked, we can select the
         # checkbox.
         if results.length is 0
-            @model.toggleViewSelected()
+            isShiftPressed = event.shiftKey or false
+            @model.toggleViewSelected isShiftPressed
 
 
     onKeyPress: (e) =>
@@ -365,7 +366,9 @@ module.exports = class FileView extends BaseView
             @onCancelClicked()
 
 
-    onSelectClicked: -> @model.toggleViewSelected()
+    onSelectClicked: (event) ->
+        isShiftPressed = event.shiftKey or false
+        @model.toggleViewSelected isShiftPressed
 
 
     onToggleSelect: ->
@@ -384,8 +387,8 @@ module.exports = class FileView extends BaseView
         if @model.isUploading() or @model.isServerUploading()
             @$el.addClass 'uploading'
             @addProgressBar()
+            @blockDownloadLink()
             @blockNameLink()
-            @blockNameClick()
         else
             @$el.removeClass 'uploading'
             @$el.toggleClass 'broken', @model.isBroken()

--- a/client/app/views/file_view.coffee
+++ b/client/app/views/file_view.coffee
@@ -384,11 +384,19 @@ module.exports = class FileView extends BaseView
         if @model.isUploading() or @model.isServerUploading()
             @$el.addClass 'uploading'
             @addProgressBar()
-            @blockDownloadLink()
+            @blockNameLink()
+            @blockNameClick()
         else
             @$el.removeClass 'uploading'
             @$el.toggleClass 'broken', @model.isBroken()
             @addTags()
+
+        # When folders are drag and drop, they can be clicked before being
+        # actually created, resulting in an error. Folders don't rely
+        # on `isUploading` because it is needless, so they are treated
+        # separately.
+        if @model.isNew()
+            @blockNameLink()
 
 
         @hideLoading()
@@ -418,6 +426,11 @@ module.exports = class FileView extends BaseView
     # Make download link inactive.
     blockDownloadLink: ->
         @$('a.caption.btn').click (event) -> event.preventDefault()
+
+
+    # Make name link inactive.
+    blockNameLink: ->
+        @$('.link-wrapper > a').click (event) -> event.preventDefault()
 
 
     # Show loading spinner.

--- a/client/app/views/file_view.coffee
+++ b/client/app/views/file_view.coffee
@@ -27,6 +27,7 @@ module.exports = class FileView extends BaseView
         'click a.broken-button': 'onDeleteClicked'
         'keydown input.file-edit-name': 'onKeyPress'
         'change input.selector': 'onSelectChanged'
+        'click div.selector-wrapper button': 'onSelectClicked'
 
     mimeClasses:
         'application/octet-stream'      : 'fa-file-o'
@@ -107,6 +108,7 @@ module.exports = class FileView extends BaseView
             attachmentUrl: @model.getAttachmentUrl()
             downloadUrl: @model.getDownloadUrl()
             clearance: @model.getClearance()
+            isViewSelected: @model.isViewSelected()
 
 
     initialize: (options) ->
@@ -337,23 +339,23 @@ module.exports = class FileView extends BaseView
             'a.file-edit-save'
             'a.file-edit-cancel'
             'span.error'
+            '.selector-wrapper'
         ]
 
         # Map them to an actual DOM element.
         forbiddenElements = forbiddenSelectors.map (selector) =>
-            return @$(selector)[0]
+            return @$(selector)?[0] or null
 
         # For each forbidden element, check if it, or one of its children, has
         # been clicked.
         results = forbiddenElements.filter (element) ->
-            return element == event.target or $.contains(element, event.target)
+            return element? and
+                (element is event.target or $.contains(element, event.target))
 
         # If none of the forbidden elements has been clicked, we can select the
         # checkbox.
         if results.length is 0
-            # Simulate a click, so it can be caught by other views managing the
-            # selection.
-            @$('input.selector').click()
+            @model.toggleViewSelected()
 
 
     onKeyPress: (e) =>
@@ -363,22 +365,19 @@ module.exports = class FileView extends BaseView
             @onCancelClicked()
 
 
-    onSelectChanged: (event) ->
-        isChecked = $(event.target).is ':checked'
-        @$el.toggleClass 'selected', isChecked
-        @model.isSelected = isChecked
-
-        @onToggleSelect()
-        return true
+    onSelectClicked: -> @model.toggleViewSelected()
 
 
     onToggleSelect: ->
-        @$el.toggleClass 'selected', @model.isSelected
-        @$('input.selector').prop 'checked', @model.isSelected
-        if @model.isSelected
-            @$('.file-move, .file-delete').addClass 'hidden'
+        isViewSelected = @model.isViewSelected()
+        @$el.toggleClass 'selected', isViewSelected
+
+        if isViewSelected
+            @$('.selector-wrapper i').removeClass 'fa-square-o'
+            @$('.selector-wrapper i').addClass 'fa-check-square-o'
         else
-            @$('.file-move, .file-delete').removeClass 'hidden'
+            @$('.selector-wrapper i').removeClass 'fa-check-square-o'
+            @$('.selector-wrapper i').addClass 'fa-square-o'
 
 
     afterRender: ->

--- a/client/app/views/file_view.coffee
+++ b/client/app/views/file_view.coffee
@@ -15,6 +15,7 @@ module.exports = class FileView extends BaseView
     templateSearch : require './templates/file_search'
 
     events:
+        'click': 'onLineClicked'
         'click a.file-tags': 'onTagClicked'
         'click a.file-delete': 'onDeleteClicked'
         'click a.file-share': 'onShareClicked'
@@ -321,6 +322,38 @@ module.exports = class FileView extends BaseView
     # been canceled for two seconds before removing the whole file line.
     onCancelUploadClicked: ->
         @uploadQueue.abort @model
+
+
+    # When a line is clicked, it should mark the item as selected, unless the
+    # user clicked a button.
+    onLineClicked: (event) ->
+
+        # List of selectors that will prevent the selection if they, or one
+        # of their children, are clicked.
+        forbiddenSelectors = [
+            '.operations'
+            '.tags'
+            '.link-wrapper'
+            'a.file-edit-save'
+            'a.file-edit-cancel'
+            'span.error'
+        ]
+
+        # Map them to an actual DOM element.
+        forbiddenElements = forbiddenSelectors.map (selector) =>
+            return @$(selector)[0]
+
+        # For each forbidden element, check if it, or one of its children, has
+        # been clicked.
+        results = forbiddenElements.filter (element) ->
+            return element == event.target or $.contains(element, event.target)
+
+        # If none of the forbidden elements has been clicked, we can select the
+        # checkbox.
+        if results.length is 0
+            # Simulate a click, so it can be caught by other views managing the
+            # selection.
+            @$('input.selector').click()
 
 
     onKeyPress: (e) =>

--- a/client/app/views/files.coffee
+++ b/client/app/views/files.coffee
@@ -25,9 +25,18 @@ module.exports = class FilesView extends ViewCollection
             isSearchMode: options.isSearchMode
             uploadQueue: options.uploadQueue
 
+        @numSelectedElements = options.numSelectedElements
+
         @chevron = order: @collection.order, type: @collection.type
 
         @listenTo @collection, 'add remove', @updateNbFiles
+
+
+    getRenderData: ->
+        _.extend super(),
+            numSelectedElements: @numSelectedElements
+            numElements: @collection.size()
+
 
     afterRender: ->
         super()

--- a/client/app/views/folder.coffee
+++ b/client/app/views/folder.coffee
@@ -77,6 +77,7 @@ module.exports = class FolderView extends BaseView
         # upload queue
         @listenTo @uploadQueue, 'conflict', @conflictQueue.push
         @listenTo @uploadQueue, 'folderError', @onMozFolderError
+        @listenTo @uploadQueue, 'existingFolderError', @onExistingFolderError
 
         return this
 
@@ -515,4 +516,10 @@ module.exports = class FolderView extends BaseView
     # Display an error when the user tries to upload a folder in Firefox.
     onMozFolderError: =>
         Modal.error t('modal error firefox dragdrop folder')
+
+
+    # Display an error when the user tries to drag and drop an existing folder.
+    onExistingFolderError: (model) ->
+        Modal.error t('modal error existing folder', name: model.get('name'))
+
 

--- a/client/app/views/folder.coffee
+++ b/client/app/views/folder.coffee
@@ -392,8 +392,14 @@ module.exports = class FolderView extends BaseView
 
 
     # we don't show the same actions wether there are selected elements or not
-    toggleFolderActions: ->
+    toggleFolderActions: (isShiftPressed) ->
+
         selectedElements = @getSelectedElements()
+
+        # If shift key is hold, the user wants to select multiple elements in
+        # one click.
+        if isShiftPressed
+            @handleSelectWithShift()
 
         if selectedElements.length > 0
             @$('#share-state').hide()
@@ -414,6 +420,7 @@ module.exports = class FolderView extends BaseView
                 @$('#button-new-folder').show()
             @$('#bulk-actions-btngroup').removeClass 'enabled'
 
+
         # Check if all checkbox should be selected. It is selected
         # when it's forced or when collection length == amount of selected
         # files
@@ -429,6 +436,31 @@ module.exports = class FolderView extends BaseView
             @$('#select-all i').removeClass 'fa-square-o'
             @$('#select-all i').removeClass 'fa-check-square-o'
             @$('#select-all i').addClass 'fa-minus-square-o'
+
+
+    # Handle the selection of multiple items within a range.
+    handleSelectWithShift: ->
+        selectedElements = @getSelectedElements()
+
+        # There must be at least two items to be able to select items between
+        # them.
+        if selectedElements.length >= 2
+
+            # Define the range within items will be selected.
+            firstSelected = selectedElements[0]
+            lastSelected = selectedElements[selectedElements.length - 1]
+            firstSelectedIndex = @collection.indexOf firstSelected
+            lastSelectedIndex = @collection.indexOf lastSelected
+
+            @collection
+                # Get the items to select.
+                .filter (model, index) ->
+                    return firstSelectedIndex < index < lastSelectedIndex and
+                           not model.isViewSelected()
+
+                # Select them.
+                .forEach (model) -> model.toggleViewSelected()
+
 
     ###
         Bulk actions management

--- a/client/app/views/styles/_main.styl
+++ b/client/app/views/styles/_main.styl
@@ -571,11 +571,6 @@ tr.folder-row
     &.selected > td
         background lightblue + 70% !important
 
-    &.selected
-        .icon-zone
-            .fa
-                display: none
-
     td
         vertical-align: baseline
 
@@ -595,6 +590,7 @@ tr.folder-row
 
     // the filename
     .caption
+        display inline-block
         font-size: 16px
         font-family: 'Source Sans Pro', sans-serif
         padding: 0
@@ -606,42 +602,38 @@ tr.folder-row
             padding-top: 4px
 
             input[type=checkbox]
-                display none
                 width 20px
-                margin 0 15px 0 0
+                margin 0 10px 0 0
                 cursor pointer
-                &:checked
-                    display inline-block
-                &:checked + .fa
-                    display none
 
         .icon-zone:hover
-            .fa
-                display: none
             .spinholder
-                display: none
-            input[type=checkbox]
-                display: inline
+                display none
 
         .fa-users
         .fa-share-alt
         .fa-globe
-            position: absolute
-            top: 12px
-            left: -3px
-            font-size: 12px
+            position absolute
+            top 10px
+            left -3px
+            font-size 12px
+            z-index 10
 
 
-    .caption:hover
-        color: orange - 10%
-        border: 1px solid transparent
-        text-decoration: none
+        .link-wrapper
+            display inline-block
+            &:hover
+                color orange - 10%
+                border 0
+                text-decoration none
+
 
     .spinholder
         vertical-align: top
-        display: inline
-        margin: 0
-        padding: 0 18px 0 5px
+        display none
+        margin 0
+        padding 0 20px 0 0
+        width 15px
 
     // the toolbox - delete, rename, etc
     .operations
@@ -714,8 +706,8 @@ tr.folder-row
                 box-shadow: 1px 3px 2px rgba(0, 0, 0, 0.2) inset, 0 1px 2px rgba(0, 0, 0, 0.0)
 
     i.fa
-        margin: 0px 15px 0 0
-        width: 20px
+        margin 0 5px 0 0
+        width 15px
 
     .icon
         font-size: 14px

--- a/client/app/views/styles/_main.styl
+++ b/client/app/views/styles/_main.styl
@@ -300,6 +300,10 @@ div#affixbar
         border-radius 10px
         margin 0 2.5px
 
+    // If two or more icons are used, they should be separated by a small margin.
+    #button-bulk-move span.fa:not(:first-of-type)
+        margin-left 5px
+
 #uploader
     cursor: pointer
 

--- a/client/app/views/styles/_main.styl
+++ b/client/app/views/styles/_main.styl
@@ -627,6 +627,10 @@ tr.folder-row
                 border 0
                 text-decoration none
 
+                // Override default behaviour
+                a
+                    color orange - 10%
+
 
     .spinholder
         vertical-align: top

--- a/client/app/views/styles/_main.styl
+++ b/client/app/views/styles/_main.styl
@@ -527,6 +527,19 @@ table#table-items
             display: none
 
 
+
+        button#select-all
+            border none
+            background transparent
+            width 20px
+            margin 0 10px 0 0
+            padding 0
+
+            i.fa
+                font-size 16px
+                margin 0
+
+
 tr.folder-row
 
     .file-path
@@ -598,13 +611,18 @@ tr.folder-row
         margin-right: 10px
 
         .selector-wrapper
-            display: inline
-            padding-top: 4px
+            display inline
+            padding-top 4px
 
-            input[type=checkbox]
+            button
+                border none
+                background transparent
                 width 20px
                 margin 0 10px 0 0
-                cursor pointer
+                padding 0
+
+                i.fa
+                    margin 0
 
         .icon-zone:hover
             .spinholder

--- a/client/app/views/templates/file.jade
+++ b/client/app/views/templates/file.jade
@@ -7,47 +7,54 @@ td
 
     block title
       if model.type == 'folder'
-        .caption.btn.btn-link
+        .caption
           span.icon-zone
-            div.spinholder
-              img(src="images/spinner.svg")
             div.selector-wrapper
               input.selector(type="checkbox")
+
+          div.link-wrapper.btn-link
+            div.spinholder
+              img(src="images/spinner.svg")
             if clearance == 'public'
-              span.fa.fa-globe
               i.fa.fa-folder
+                span.fa.fa-globe
             else if clearance && clearance.length > 0
-              span.fa.fa-globe
               i.fa.fa-folder-o
+                span.fa.fa-globe
             else
               i.fa.fa-folder
-          a.btn-link(href="#folders/#{model.id}", title="#{t('open folder')}")
-            span
-              | #{model.name}
+            a.btn-link(href="#folders/#{model.id}", title="#{t('open folder')}")
+              span= model.name
+
       else if model.type == 'file'
-        .caption.btn.btn-link(data-file-url="#{attachmentUrl}")
+        .caption(data-file-url="#{attachmentUrl}")
           span.icon-zone
-            div.spinholder
-              img(src="images/spinner.svg")
-            if clearance == 'public'
-              span.fa.fa-globe
-            else if clearance && clearance.length > 0
-              span.fa.fa-globe
             div.selector-wrapper
               input.selector(type="checkbox")
+
+          div.link-wrapper.btn-link
+            div.spinholder
+              img(src="images/spinner.svg")
             if model.mime && this.mimeClasses[model.mime]
               i(class="fa #{this.mimeClasses[model.mime]}")
+                if clearance == 'public'
+                  span.fa.fa-globe
+                else if clearance && clearance.length > 0
+                  span.fa.fa-globe
             else
               i.fa.fa-file-o
-          if !isBroken
-              a.btn-link(
-                href="#{attachmentUrl}",
-                title="#{t('download file')}", target="_blank")
-                  span
-                    | #{model.name}
-          else
-            span.file-name
-              | #{model.name}
+                if clearance == 'public'
+                  span.fa.fa-globe
+                else if clearance && clearance.length > 0
+                  span.fa.fa-globe
+            if !isBroken
+                a.btn-link(
+                  href="#{attachmentUrl}",
+                  title="#{t('download file')}", target="_blank")
+                    span
+                      | #{model.name}
+            else
+              span.file-name= model.name
 
     block tags
       ul.tags

--- a/client/app/views/templates/file.jade
+++ b/client/app/views/templates/file.jade
@@ -10,7 +10,11 @@ td
         .caption
           span.icon-zone
             div.selector-wrapper
-              input.selector(type="checkbox")
+              button
+                if isViewSelected
+                  i.fa.fa-check-square-o
+                else
+                  i.fa.fa-square-o
 
           div.link-wrapper.btn-link
             div.spinholder
@@ -30,7 +34,11 @@ td
         .caption(data-file-url="#{attachmentUrl}")
           span.icon-zone
             div.selector-wrapper
-              input.selector(type="checkbox")
+              button
+                if isViewSelected
+                  i.fa.fa-check-square-o
+                else
+                  i.fa.fa-square-o
 
           div.link-wrapper.btn-link
             div.spinholder

--- a/client/app/views/templates/files.jade
+++ b/client/app/views/templates/files.jade
@@ -2,7 +2,14 @@ table#table-items.table.table-hover
   thead
     tr.table-headers
       td
-        input#select-all(type="checkbox")
+        button#select-all
+          if numSelectedElements == 0 || numElements == 0
+            i.fa.fa-square-o
+          else if numSelectedElements == numElements
+            i.fa.fa-check-square-o
+          else
+            i.fa.fa-minus-square-o
+
         span= t('name')
         a#down-name.btn.fa.fa-chevron-down.unactive
         a#up-name.btn.fa.fa-chevron-up.unactive

--- a/client/app/views/templates/folder.jade
+++ b/client/app/views/templates/folder.jade
@@ -49,11 +49,12 @@
                   if isPublic
                       a#button-bulk-download(title="#{t('download all')}").btn.btn-cozy-contrast
                         span.label #{t("download all")}&nbsp;
-                        span.fa.fa-arrow-down.icon-white
+                        span.fa.fa-download.icon-white
                   else
                       a#button-bulk-download(title="#{t('download all')}").btn.btn-cozy
-                        span.fa.fa-arrow-down
+                        span.fa.fa-download
                   a#button-bulk-move(title="#{t('move all')}").btn.btn-cozy.btn-cozy
+                    span.fa.fa-file
                     span.fa.fa-arrow-right
                   a#button-bulk-remove(title="#{t('remove all')}").btn.btn-cozy.btn-cozy
                     span.fa.fa-trash-o

--- a/client/app/views/upload_status.coffee
+++ b/client/app/views/upload_status.coffee
@@ -92,15 +92,12 @@ module.exports = class UploadStatusView extends BaseView
         else
             @render()
 
-        @counter.text @collection.length
-        @counterDone.text @collection.loaded
         @render() if @completed and not @collection.completed
 
 
     afterRender: ->
         @$el.removeClass 'success danger warning'
-        @counter = @$ '.counter'
-        @counterDone = @$ '.counter-done'
+
         @progressbar = @$ '.progress-bar-info'
         @progressbarContent = @$ '.progress-bar-content'
         @dismiss = @$('#dismiss').hide()

--- a/client/vendor/scripts/clearance_modal.js
+++ b/client/vendor/scripts/clearance_modal.js
@@ -17,7 +17,7 @@ require.register("cozy-clearance/contact_autocomplete", function(exports, requir
   return input.typeahead({
     source: function(query) {
       var contacts, items, regexp;
-      regexp = new RegExp(query);
+      regexp = new RegExp(query, 'i');
       contacts = contactCollection.filter(function(contact) {
         return contact.match(regexp);
       });
@@ -27,9 +27,9 @@ require.register("cozy-clearance/contact_autocomplete", function(exports, requir
           return items.push({
             id: contact.id,
             hasPicture: contact.get('hasPicture'),
-            display: (contact.get('name')) + " &lt;" + email + "&gt;",
+            display: "" + (contact.get('name')) + " &lt;" + email + "&gt;",
             toString: function() {
-              return email + ";" + contact.id;
+              return "" + email + ";" + contact.id;
             }
           });
         });
@@ -72,20 +72,20 @@ require.register("cozy-clearance/contact_autocomplete", function(exports, requir
   });
 };
 
-  
+
 });
 
 require.register("cozy-clearance/contact_collection", function(exports, require, module){
   var Contact, collection,
-  extend = function(child, parent) { for (var key in parent) { if (hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; },
-  hasProp = {}.hasOwnProperty;
+  __hasProp = {}.hasOwnProperty,
+  __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; };
 
 collection = new Backbone.Collection();
 
 collection.url = 'clearance/contacts';
 
-collection.model = Contact = (function(superClass) {
-  extend(Contact, superClass);
+collection.model = Contact = (function(_super) {
+  __extends(Contact, _super);
 
   function Contact() {
     return Contact.__super__.constructor.apply(this, arguments);
@@ -132,20 +132,20 @@ collection.handleRealtimeContactEvent = function(event) {
 
 module.exports = collection;
 
-  
+
 });
 
 require.register("cozy-clearance/modal", function(exports, require, module){
   var Modal,
-  bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; },
-  extend = function(child, parent) { for (var key in parent) { if (hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; },
-  hasProp = {}.hasOwnProperty;
+  __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; },
+  __hasProp = {}.hasOwnProperty,
+  __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; };
 
-Modal = (function(superClass) {
-  extend(Modal, superClass);
+Modal = (function(_super) {
+  __extends(Modal, _super);
 
   function Modal() {
-    this.closeOnEscape = bind(this.closeOnEscape, this);
+    this.closeOnEscape = __bind(this.closeOnEscape, this);
     return Modal.__super__.constructor.apply(this, arguments);
   }
 
@@ -290,7 +290,7 @@ Modal.error = function(text, cb) {
 
 module.exports = Modal;
 
-  
+
 });
 
 require.register("cozy-clearance/modal_share_template", function(exports, require, module){
@@ -298,7 +298,7 @@ require.register("cozy-clearance/modal_share_template", function(exports, requir
 var buf = [];
 var jade_mixins = {};
 var jade_interp;
-;var locals_for_with = (locals || {});(function (JSON, Object, clearance, makeURL, model, possible_permissions, t, type, undefined) {
+;var locals_for_with = (locals || {});(function (t, type, model, JSON, clearance, makeURL, undefined, Object, possible_permissions) {
 buf.push("<div><div id=\"select-mode-section\"><p>" + (jade.escape(null == (jade_interp = t('modal question ' + type + ' shareable', {name: model.get('name')})) ? "" : jade_interp)) + "</p><p><button id=\"share-public\" class=\"button btn-cozy\">" + (jade.escape(null == (jade_interp = t('shared')) ? "" : jade_interp)) + "</button>&nbsp;<button id=\"share-private\" class=\"button btn-cozy\">" + (jade.escape(null == (jade_interp = t('private')) ? "" : jade_interp)) + "</button></p></div><p>&nbsp;</p></div><!-- If no clearance are set, we consider it's a private object.-->");
 if ( JSON.stringify(clearance) == '[]')
 {
@@ -448,17 +448,17 @@ buf.push("<a" + (jade.attr("data-key", key, true, false)) + (jade.attr("title", 
 
 }
 buf.push("</ul>");
-}}.call(this,"JSON" in locals_for_with?locals_for_with.JSON:typeof JSON!=="undefined"?JSON:undefined,"Object" in locals_for_with?locals_for_with.Object:typeof Object!=="undefined"?Object:undefined,"clearance" in locals_for_with?locals_for_with.clearance:typeof clearance!=="undefined"?clearance:undefined,"makeURL" in locals_for_with?locals_for_with.makeURL:typeof makeURL!=="undefined"?makeURL:undefined,"model" in locals_for_with?locals_for_with.model:typeof model!=="undefined"?model:undefined,"possible_permissions" in locals_for_with?locals_for_with.possible_permissions:typeof possible_permissions!=="undefined"?possible_permissions:undefined,"t" in locals_for_with?locals_for_with.t:typeof t!=="undefined"?t:undefined,"type" in locals_for_with?locals_for_with.type:typeof type!=="undefined"?type:undefined,"undefined" in locals_for_with?locals_for_with.undefined:typeof undefined!=="undefined"?undefined:undefined));;return buf.join("");
+}}("t" in locals_for_with?locals_for_with.t:typeof t!=="undefined"?t:undefined,"type" in locals_for_with?locals_for_with.type:typeof type!=="undefined"?type:undefined,"model" in locals_for_with?locals_for_with.model:typeof model!=="undefined"?model:undefined,"JSON" in locals_for_with?locals_for_with.JSON:typeof JSON!=="undefined"?JSON:undefined,"clearance" in locals_for_with?locals_for_with.clearance:typeof clearance!=="undefined"?clearance:undefined,"makeURL" in locals_for_with?locals_for_with.makeURL:typeof makeURL!=="undefined"?makeURL:undefined,"undefined" in locals_for_with?locals_for_with.undefined:typeof undefined!=="undefined"?undefined:undefined,"Object" in locals_for_with?locals_for_with.Object:typeof Object!=="undefined"?Object:undefined,"possible_permissions" in locals_for_with?locals_for_with.possible_permissions:typeof possible_permissions!=="undefined"?possible_permissions:undefined));;return buf.join("");
 }
 module.exports = template;
-  
+
 });
 
 require.register("cozy-clearance/modal_share_view", function(exports, require, module){
   var CozyClearanceModal, Modal, clearanceDiff, contactCollection, contactTypeahead, randomString, request,
-  bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; },
-  extend = function(child, parent) { for (var key in parent) { if (hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; },
-  hasProp = {}.hasOwnProperty;
+  __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; },
+  __hasProp = {}.hasOwnProperty,
+  __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; };
 
 Modal = require("./modal");
 
@@ -504,20 +504,20 @@ request = function(method, url, data, options) {
   return $.ajax(_.extend(params, options));
 };
 
-module.exports = CozyClearanceModal = (function(superClass) {
-  extend(CozyClearanceModal, superClass);
+module.exports = CozyClearanceModal = (function(_super) {
+  __extends(CozyClearanceModal, _super);
 
   function CozyClearanceModal() {
-    this.onClose = bind(this.onClose, this);
-    this.onYes = bind(this.onYes, this);
-    this.onNo = bind(this.onNo, this);
-    this.revoke = bind(this.revoke, this);
-    this.onGuestAdded = bind(this.onGuestAdded, this);
-    this.getClearanceWithContacts = bind(this.getClearanceWithContacts, this);
-    this.existsEmail = bind(this.existsEmail, this);
-    this.typeaheadFilter = bind(this.typeaheadFilter, this);
-    this.makeURL = bind(this.makeURL, this);
-    this.getRenderData = bind(this.getRenderData, this);
+    this.onClose = __bind(this.onClose, this);
+    this.onYes = __bind(this.onYes, this);
+    this.onNo = __bind(this.onNo, this);
+    this.revoke = __bind(this.revoke, this);
+    this.onGuestAdded = __bind(this.onGuestAdded, this);
+    this.getClearanceWithContacts = __bind(this.getClearanceWithContacts, this);
+    this.existsEmail = __bind(this.existsEmail, this);
+    this.typeaheadFilter = __bind(this.typeaheadFilter, this);
+    this.makeURL = __bind(this.makeURL, this);
+    this.getRenderData = __bind(this.getRenderData, this);
     return CozyClearanceModal.__super__.constructor.apply(this, arguments);
   }
 
@@ -641,7 +641,7 @@ module.exports = CozyClearanceModal = (function(superClass) {
   };
 
   CozyClearanceModal.prototype.makePrivate = function() {
-    if (this.isPublicClearance()) {
+    if (!isPrivateClearance()) {
       this.lastClearance = this.model.get('clearance');
       this.model.set({
         clearance: []
@@ -754,8 +754,8 @@ module.exports = CozyClearanceModal = (function(superClass) {
   };
 
   CozyClearanceModal.prototype.onGuestAdded = function(result) {
-    var clearance, contactid, email, isEmailEmpty, key, perm, ref;
-    ref = result.split(';'), email = ref[0], contactid = ref[1];
+    var clearance, contactid, email, isEmailEmpty, key, perm, _ref;
+    _ref = result.split(';'), email = _ref[0], contactid = _ref[1];
     isEmailEmpty = email === '' || email.indexOf('@') < 1;
     if (!(this.existsEmail(email) || isEmailEmpty)) {
       key = randomString();
@@ -869,5 +869,5 @@ module.exports = CozyClearanceModal = (function(superClass) {
 
 })(Modal);
 
-  
+
 });

--- a/server/controllers/files.coffee
+++ b/server/controllers/files.coffee
@@ -54,12 +54,10 @@ module.exports.getAttachment = (req, res, next) ->
 
     # Prevent server from stopping if the download is very slow.
     isDownloading = true
-    keepAlive = ->
+    do keepAlive = ->
         if isDownloading
             feed.publish 'usage.application', 'files'
             setTimeout keepAlive, 60 * 1000
-
-    keepAlive()
 
     # Configure headers so clients know they should read and not download.
     encodedFileName = encodeURIComponent req.file.name
@@ -79,12 +77,11 @@ module.exports.downloadAttachment = (req, res, next) ->
 
     # Prevent server from stopping if the download is very slow.
     isDownloading = true
-    keepAlive = ->
+    do keepAlive = ->
         if isDownloading
             feed.publish 'usage.application', 'files'
             setTimeout keepAlive, 60 * 1000
 
-    keepAlive()
 
     # Configure headers so clients know they should download, and that they
     # can make up the file name.


### PR DESCRIPTION
Here are the most impactful changes:

* When drag and dropping an existing folder, it caused weird behaviour. Overwriting a folder is a bit tricky, so I did a fix to just prevent it, rather than implementing a whole system to handle it.

* I did multiple changes to the selection of items (see https://github.com/cozy/cozy-files/issues/283):
    * checkboxes are now always visible. It's better for mobile, and users complain they don't find it.
    * the "select all" checkbox now has 3 states: when it's empty, when some items are selected, when all items are selected
    * you can select an item by clicking the line (except if you click one of the action button)