### PR TITLE
Improved performance

### DIFF
--- a/client/app/collections/files.coffee
+++ b/client/app/collections/files.coffee
@@ -101,17 +101,6 @@ module.exports = class FileCollection extends Backbone.Collection
                             comparator: @comparator
 
 
-    # Return a singleton representing a sub collection (projection) for
-    # files in upload cycle.
-    getFilesBeingUploaded: ->
-        unless @filesBeingUploaded?
-            @filesBeingUploaded = new BackboneProjections.Filtered @,
-                filter: (file) -> return file.inUploadCycle()
-                comparator: @comparator
-
-        return @filesBeingUploaded
-
-
     comparator: (f1, f2) ->
 
         # default values

--- a/client/app/models/file.coffee
+++ b/client/app/models/file.coffee
@@ -137,7 +137,7 @@ module.exports = class File extends Backbone.Model
 
     setSelectedViewState: (viewSelected, isShiftPressed = false) ->
         @viewSelected = viewSelected
-        @trigger 'toggle-select', isShiftPressed
+        @trigger 'toggle-select', cid: @cid, isShiftPressed: isShiftPressed
 
 
     # Remove server's additional information

--- a/client/app/views/files.coffee
+++ b/client/app/views/files.coffee
@@ -18,6 +18,20 @@ module.exports = class FilesView extends ViewCollection
         'click #up-lastModification'   : 'onChangeOrder'
         'click #down-lastModification' : 'onChangeOrder'
 
+        # Event delegation.
+        'click a.file-tags': (e) -> @viewProxy 'onTagClicked', e
+        'click a.file-delete': (e) -> @viewProxy 'onDeleteClicked', e
+        'click a.file-share': (e) -> @viewProxy 'onShareClicked', e
+        'click a.file-edit': (e) -> @viewProxy 'onEditClicked', e
+        'click a.file-edit-save': (e) -> @viewProxy 'onSaveClicked', e
+        'click a.file-edit-cancel': (e) -> @viewProxy 'onCancelClicked', e
+        'click a.cancel-upload-button': (e) -> @viewProxy 'onCancelUploadClicked', e
+        'click a.file-move': (e) -> @viewProxy 'onMoveClicked', e
+        'click a.broken-button': (e) -> @viewProxy 'onDeleteClicked', e
+        'keydown input.file-edit-name': (e) -> @viewProxy 'onKeyPress', e
+        'click div.selector-wrapper button': (e) -> @viewProxy 'onSelectClicked', e
+        'click tr.folder-row': (e) -> @viewProxy 'onLineClicked', e
+
     initialize: (options) ->
         super options
 
@@ -31,6 +45,13 @@ module.exports = class FilesView extends ViewCollection
 
         @listenTo @collection, 'add remove', @updateNbFiles
 
+        # Event delegation.
+        @listenTo @collection, 'change', _.partial(@viewProxy, 'refresh')
+        @listenTo @collection, 'sync error', _.partial(@viewProxy, 'onSyncError')
+        @listenTo @collection, 'toggle-select', _.partial(@viewProxy, 'onToggleSelect')
+        @listenTo @collection, 'add remove reset',  _.partial(@viewProxy, 'onCollectionChanged')
+        @listenTo @collection, 'upload-complete',  _.partial(@viewProxy, 'onUploadComplete')
+
 
     getRenderData: ->
         _.extend super(),
@@ -42,6 +63,33 @@ module.exports = class FilesView extends ViewCollection
         super()
         @displayChevron @chevron.order, @chevron.type
         @updateNbFiles()
+
+
+    # Manage event delegation. Events are listen to on the collection level,
+    # then the callback are called on the view that originally triggered them.
+    #
+    # * `methodName` is the method that will be called on the View.
+    # * `object` can be a File model or a DOMElement within FileView.$el
+    viewProxy: (methodName, object) ->
+
+        # Get view's cid. Views are indexed by cid. Object can be a File model
+        # or a DOMElement within FileView.$el.
+        if object.cid?
+            cid = object.cid
+        else
+            cid = @$(object.target).parents('tr').data 'cid'
+
+            unless cid?
+                cid = @$(object.currentTarget).data 'cid'
+
+        # Get the view.
+        view = _.find @views, (view) -> view.model.cid is cid
+
+        # Call `methodName` on the related view.
+        args = [].splice.call arguments, 1
+        view[methodName].apply view, args
+
+
 
     updateNbFiles: ->
         nbElements = @collection.length

--- a/client/app/views/files.coffee
+++ b/client/app/views/files.coffee
@@ -85,9 +85,11 @@ module.exports = class FilesView extends ViewCollection
         # Get the view.
         view = _.find @views, (view) -> view.model.cid is cid
 
-        # Call `methodName` on the related view.
-        args = [].splice.call arguments, 1
-        view[methodName].apply view, args
+        # In case of deletion, view may not exist anymore.
+        if view?
+            # Call `methodName` on the related view.
+            args = [].splice.call arguments, 1
+            view[methodName].apply view, args
 
 
 

--- a/client/app/views/folder.coffee
+++ b/client/app/views/folder.coffee
@@ -392,7 +392,8 @@ module.exports = class FolderView extends BaseView
 
 
     # we don't show the same actions wether there are selected elements or not
-    toggleFolderActions: (isShiftPressed) ->
+    toggleFolderActions: (event) ->
+        {isShiftPressed} = event
 
         selectedElements = @getSelectedElements()
 

--- a/server/controllers/folders.coffee
+++ b/server/controllers/folders.coffee
@@ -307,7 +307,7 @@ module.exports.findContent = (req, res, next) ->
                 # Retrieves the folders and inject the inherited clearance
                 (cb) -> Folder.byFolder key: key, (err, folders) ->
                     # if it's a request from a guest, we limit the results
-                    unless isPublic
+                    if isPublic
                         Folder.injectInheritedClearance folders, cb
                     else
                         cb null, folders
@@ -315,7 +315,7 @@ module.exports.findContent = (req, res, next) ->
                 # Retrieves the files and inject the inherited clearance
                 (cb) -> File.byFolder key: key, (err, files) ->
                     # if it's a request from a guest, we limit the results
-                    unless isPublic
+                    if isPublic
                         File.injectInheritedClearance files, cb
                     else
                         cb null, files


### PR DESCRIPTION
Some small changes to improve performance, part of the work on big lists.

* The first one is event delegation. I took the code from @m4dz work in #226.

* I also find a bug where a high cost operation was performed whereas it should not. Getting a folder's content with 1000 elements is now <1s, whereas it was around 18s before. It doesn't remove the slow feeling in the client, but it's a massive speed increase.