### PR TITLE
Fix #382 - clear files selection after each operation

### DIFF
--- a/client/app/views/folder.coffee
+++ b/client/app/views/folder.coffee
@@ -101,7 +101,7 @@ module.exports = class FolderView extends BaseView
 
     destroy: ->
         # reset selection for each models
-        @collection.forEach (element) -> element.isSelected = false
+        @collection.forEach (element) -> element.viewSelected = false
 
         # properly destroy subviews
         @breadcrumbsView.destroy()
@@ -498,6 +498,7 @@ module.exports = class FolderView extends BaseView
                 # model.destroy, to prevent elements from disappearing in the
                 # meantime.
                 for model in selectedElements
+                    model.viewSelected = false
                     @baseCollection.remove(model)
 
                 # Filter the destroys' result to know which have failed so they

--- a/client/app/views/modal_bulk_move.coffee
+++ b/client/app/views/modal_bulk_move.coffee
@@ -102,6 +102,7 @@ module.exports = class ModalBulkMoveView extends Modal
         window.pendingOperations.move++
         # Process the update 1 by 1
         async.eachSeries @collection, (model, cb) ->
+            model.viewSelected = false
             id = model.get 'id'
             type = model.get 'type'
             client.put "#{type}s/#{id}", path: newPath, cb


### PR DESCRIPTION
Steps to reproduce the bug:

1. Create a directory `foo`, with a file `bar` inside it
2. Upload a file `baz` somewhere else
3. Select the `baz` file and move it inside the `foo` folder
4. Go to the `foo` folder
5. Select `bar` and delete it

Without the fix, both `bar` and `baz` are deleted, even if `bar` does not look like it is selected.

