### PR TITLE
Log error and 206 status code when the user cancel an archive download

### DIFF
--- a/server/controllers/folders.coffee
+++ b/server/controllers/folders.coffee
@@ -457,7 +457,8 @@ An error occured while adding a file to archive. File: #{file.name}
 
         # Arbort archiving process when request is closed.
         req.on 'close', ->
-            archive.abort()
+            log.error """Archiving canceled by the user."""
+            res.status(206)
 
         # Set headers describing the final zip file.
         disposition = "attachment; filename=\"#{zipName}.zip\""


### PR DESCRIPTION
Fix #429 
Log an error and send 206 status code when the user cancel an archive download.
The abort() function used before didn't exist in the archive object.