### PR TITLE
Run abort archiver function if exists when canceling an archive download

### DIFF
--- a/server/controllers/folders.coffee
+++ b/server/controllers/folders.coffee
@@ -457,6 +457,8 @@ An error occured while adding a file to archive. File: #{file.name}
 
         # Arbort archiving process when request is closed.
         req.on 'close', ->
+            if typeof archive?.abort is 'function'
+                archive.abort()
             log.error """Archiving canceled by the user."""
             res.status(206)
 


### PR DESCRIPTION
Improve fix(#462) for issue #429 