### PR TITLE
Increase maxBuffer of build command

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -162,7 +162,9 @@ task 'build', 'Build CoffeeScript to Javascript', ->
               "cp -R client/public build/client/ && " + \
               "rm -rf client/app/locales/*.coffee"
 
-    exec command, (err, stdout, stderr) ->
+    options =
+        maxBuffer: 1024 * 1024
+    exec command, options, (err, stdout, stderr) ->
         if err
             logger.error "An error has occurred while compiling:\n" + err
             process.exit 1


### PR DESCRIPTION
When buffer size is greater than maxBuffer, the process is killed. It happens
when the build is run from another node process, such as cozy-ci.

cozy-ci is a tool I developed in order to ease continuous testing. It builds applications and deploy them testing Cozy instance.